### PR TITLE
Self registration env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,9 @@ var Version = "2.1.1"
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")
 
+var SelfEndpoint = os.Getenv("SELF_ENDPOINT")
+var SelfHealthCheck = os.Getenv("SELF_HEALTH_CHECK")
+
 var AuthUser = os.Getenv("AUTH_USER")
 var AuthPassword = os.Getenv("AUTH_PASSWORD")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module rincon
 
-go 1.22
+go 1.24
+
 toolchain go1.24.1
 
 require (

--- a/service/service.go
+++ b/service/service.go
@@ -148,8 +148,8 @@ func RegisterSelf() {
 	service := model.Service{
 		Name:        "Rincon",
 		Version:     config.Version,
-		Endpoint:    "http://localhost:" + config.Port,
-		HealthCheck: "http://localhost:" + config.Port + "/rincon/ping",
+		Endpoint:    config.SelfEndpoint,
+		HealthCheck: config.SelfHealthCheck,
 		UpdatedAt:   time.Now(),
 		CreatedAt:   time.Now(),
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -14,6 +14,14 @@ func VerifyConfig() {
 		config.Port = "10311"
 		SugarLogger.Debugln("PORT is not set, defaulting to 10311")
 	}
+	if config.SelfEndpoint == "" {
+		config.SelfEndpoint = "http://localhost:" + config.Port
+		SugarLogger.Debugln("SELF_ENDPOINT is not set, defaulting to http://localhost:" + config.Port)
+	}
+	if config.SelfHealthCheck == "" {
+		config.SelfHealthCheck = "http://localhost:" + config.Port + "/rincon/ping"
+		SugarLogger.Debugln("SELF_HEALTH_CHECK is not set, defaulting to http://localhost:" + config.Port + "/rincon/ping")
+	}
 	if config.AuthUser == "" {
 		config.AuthUser = "admin"
 		SugarLogger.Debugln("AUTH_USER is not set, defaulting to admin")

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -16,6 +16,12 @@ func TestVerifyConfig(t *testing.T) {
 		if config.Port != "10311" {
 			t.Errorf("Port is not set to 10311")
 		}
+		if config.SelfEndpoint != "http://localhost:10311" {
+			t.Errorf("SelfEndpoint is not set to http://localhost:10311")
+		}
+		if config.SelfHealthCheck != "http://localhost:10311/rincon/ping" {
+			t.Errorf("SelfHealthCheck is not set to http://localhost:10311/rincon/ping")
+		}
 		if config.AuthUser != "admin" {
 			t.Errorf("AuthUser is not set to admin")
 		}


### PR DESCRIPTION
Added `SELF_ENDPOINT` and `SELF_HEALTH_CHECK` env vars to allow for dynamic Rincon registration at run time.

Defaults to `http://localhost:{PORT}` and `http://localhost:{PORT}/rincon/ping` respectively.